### PR TITLE
Add Expression Evaluator and Script Watches to the debugger

### DIFF
--- a/core/math/expression.cpp
+++ b/core/math/expression.cpp
@@ -1940,7 +1940,7 @@ bool Expression::_execute(const Array &p_inputs, Object *p_instance, Expression:
 
 			const Expression::InputNode *in = static_cast<const Expression::InputNode *>(p_node);
 			if (in->index < 0 || in->index >= p_inputs.size()) {
-				r_error_str = vformat(RTR("Invalid input %i (not passed) in expression"), in->index);
+				r_error_str = vformat(RTR("Invalid input %d (not passed) in expression"), in->index);
 				return true;
 			}
 			r_ret = p_inputs[in->index];
@@ -2219,6 +2219,21 @@ void Expression::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("execute", "inputs", "base_instance", "show_error"), &Expression::execute, DEFVAL(Array()), DEFVAL(Variant()), DEFVAL(true));
 	ClassDB::bind_method(D_METHOD("has_execute_failed"), &Expression::has_execute_failed);
 	ClassDB::bind_method(D_METHOD("get_error_text"), &Expression::get_error_text);
+}
+
+Vector<Expression::ENode *> Expression::get_nodes_by_type(const ENode::Type p_type) const {
+	Vector<ENode *> filtered_nodes;
+	ENode *node = nodes;
+
+	while (node) {
+		if (node->type == p_type) {
+			filtered_nodes.push_back(node);
+		}
+
+		node = node->next;
+	}
+
+	return filtered_nodes;
 }
 
 Expression::Expression() :

--- a/core/math/expression.h
+++ b/core/math/expression.h
@@ -110,96 +110,6 @@ public:
 		FUNC_MAX
 	};
 
-	static int get_func_argument_count(BuiltinFunc p_func);
-	static String get_func_name(BuiltinFunc p_func);
-	static void exec_func(BuiltinFunc p_func, const Variant **p_inputs, Variant *r_return, Variant::CallError &r_error, String &r_error_str);
-	static BuiltinFunc find_function(const String &p_string);
-
-private:
-	static const char *func_name[FUNC_MAX];
-
-	struct Input {
-
-		Variant::Type type;
-		String name;
-
-		Input() :
-				type(Variant::NIL) {
-		}
-	};
-
-	Vector<Input> inputs;
-	Variant::Type output_type;
-
-	String expression;
-
-	bool sequenced;
-	int str_ofs;
-	bool expression_dirty;
-
-	bool _compile_expression();
-
-	enum TokenType {
-		TK_CURLY_BRACKET_OPEN,
-		TK_CURLY_BRACKET_CLOSE,
-		TK_BRACKET_OPEN,
-		TK_BRACKET_CLOSE,
-		TK_PARENTHESIS_OPEN,
-		TK_PARENTHESIS_CLOSE,
-		TK_IDENTIFIER,
-		TK_BUILTIN_FUNC,
-		TK_SELF,
-		TK_CONSTANT,
-		TK_BASIC_TYPE,
-		TK_COLON,
-		TK_COMMA,
-		TK_PERIOD,
-		TK_OP_IN,
-		TK_OP_EQUAL,
-		TK_OP_NOT_EQUAL,
-		TK_OP_LESS,
-		TK_OP_LESS_EQUAL,
-		TK_OP_GREATER,
-		TK_OP_GREATER_EQUAL,
-		TK_OP_AND,
-		TK_OP_OR,
-		TK_OP_NOT,
-		TK_OP_ADD,
-		TK_OP_SUB,
-		TK_OP_MUL,
-		TK_OP_DIV,
-		TK_OP_MOD,
-		TK_OP_SHIFT_LEFT,
-		TK_OP_SHIFT_RIGHT,
-		TK_OP_BIT_AND,
-		TK_OP_BIT_OR,
-		TK_OP_BIT_XOR,
-		TK_OP_BIT_INVERT,
-		TK_INPUT,
-		TK_EOF,
-		TK_ERROR,
-		TK_MAX
-	};
-
-	static const char *token_name[TK_MAX];
-	struct Token {
-
-		TokenType type;
-		Variant value;
-	};
-
-	void _set_error(const String &p_err) {
-		if (error_set)
-			return;
-		error_str = p_err;
-		error_set = true;
-	}
-
-	Error _get_token(Token &r_token);
-
-	String error_str;
-	bool error_set;
-
 	struct ENode {
 
 		enum Type {
@@ -332,6 +242,96 @@ private:
 		}
 	};
 
+	static int get_func_argument_count(BuiltinFunc p_func);
+	static String get_func_name(BuiltinFunc p_func);
+	static void exec_func(BuiltinFunc p_func, const Variant **p_inputs, Variant *r_return, Variant::CallError &r_error, String &r_error_str);
+	static BuiltinFunc find_function(const String &p_string);
+
+private:
+	static const char *func_name[FUNC_MAX];
+
+	struct Input {
+
+		Variant::Type type;
+		String name;
+
+		Input() :
+				type(Variant::NIL) {
+		}
+	};
+
+	Vector<Input> inputs;
+	Variant::Type output_type;
+
+	String expression;
+
+	bool sequenced;
+	int str_ofs;
+	bool expression_dirty;
+
+	bool _compile_expression();
+
+	enum TokenType {
+		TK_CURLY_BRACKET_OPEN,
+		TK_CURLY_BRACKET_CLOSE,
+		TK_BRACKET_OPEN,
+		TK_BRACKET_CLOSE,
+		TK_PARENTHESIS_OPEN,
+		TK_PARENTHESIS_CLOSE,
+		TK_IDENTIFIER,
+		TK_BUILTIN_FUNC,
+		TK_SELF,
+		TK_CONSTANT,
+		TK_BASIC_TYPE,
+		TK_COLON,
+		TK_COMMA,
+		TK_PERIOD,
+		TK_OP_IN,
+		TK_OP_EQUAL,
+		TK_OP_NOT_EQUAL,
+		TK_OP_LESS,
+		TK_OP_LESS_EQUAL,
+		TK_OP_GREATER,
+		TK_OP_GREATER_EQUAL,
+		TK_OP_AND,
+		TK_OP_OR,
+		TK_OP_NOT,
+		TK_OP_ADD,
+		TK_OP_SUB,
+		TK_OP_MUL,
+		TK_OP_DIV,
+		TK_OP_MOD,
+		TK_OP_SHIFT_LEFT,
+		TK_OP_SHIFT_RIGHT,
+		TK_OP_BIT_AND,
+		TK_OP_BIT_OR,
+		TK_OP_BIT_XOR,
+		TK_OP_BIT_INVERT,
+		TK_INPUT,
+		TK_EOF,
+		TK_ERROR,
+		TK_MAX
+	};
+
+	static const char *token_name[TK_MAX];
+	struct Token {
+
+		TokenType type;
+		Variant value;
+	};
+
+	void _set_error(const String &p_err) {
+		if (error_set)
+			return;
+		error_str = p_err;
+		error_set = true;
+	}
+
+	Error _get_token(Token &r_token);
+
+	String error_str;
+	bool error_set;
+
 	template <class T>
 	T *alloc_node() {
 		T *node = memnew(T);
@@ -356,6 +356,9 @@ public:
 	Variant execute(Array p_inputs, Object *p_base = NULL, bool p_show_error = true);
 	bool has_execute_failed() const;
 	String get_error_text() const;
+	String get_source_string() const { return expression; };
+
+	Vector<ENode *> get_nodes_by_type(const ENode::Type p_type) const;
 
 	Expression();
 	~Expression();

--- a/core/script_debugger_local.cpp
+++ b/core/script_debugger_local.cpp
@@ -144,7 +144,8 @@ void ScriptDebuggerLocal::debug(ScriptLanguage *p_script, bool p_can_continue, b
 			} else {
 
 				String expr = line.get_slicec(' ', 2);
-				String res = p_script->debug_parse_stack_level_expression(current_frame, expr);
+				String res;
+				(void)evaluate_expression(current_frame, expr, res);
 				print_line(res);
 			}
 

--- a/core/script_language.cpp
+++ b/core/script_language.cpp
@@ -530,14 +530,6 @@ String ScriptDebugger::get_watch_error_text(int p_index) const {
 }
 
 bool ScriptDebugger::_evaluate_watches(int p_stack_level, int p_watch) {
-	if (watches.size() == 0) {
-		return false;
-	}
-
-	if (evaluate_watches_mutex->try_lock() != OK) {
-		return false;
-	}
-
 	int from = p_watch;
 	int to = p_watch + 1;
 	if (p_watch == -1) {
@@ -603,7 +595,6 @@ bool ScriptDebugger::_evaluate_watches(int p_stack_level, int p_watch) {
 			data.dirty = true;
 		}
 	}
-	evaluate_watches_mutex->unlock();
 
 	return tracking_watch_changed;
 }
@@ -689,7 +680,7 @@ ScriptDebugger::ScriptDebugger() {
 	singleton = this;
 	lines_left = -1;
 	depth = -1;
-	evaluate_watches_mutex = Mutex::create();
+	evaluate_watches_safe_count = 0;
 	break_lang = NULL;
 }
 

--- a/core/script_language.cpp
+++ b/core/script_language.cpp
@@ -548,7 +548,7 @@ bool ScriptDebugger::_evaluate_watches(int p_stack_level, int p_watch) {
 	int inverse_stack_level = lang->debug_get_stack_level_count() - p_stack_level - 1;
 	bool executing_script = lang->debug_get_stack_level_count() > 0;
 	ObjectID script_owner_id = 0;
-	ExpressionContext context;
+	ExpressionContext context = get_expression_context(p_stack_level);
 
 	if (executing_script) {
 		ERR_FAIL_NULL_V(lang, false);
@@ -564,7 +564,6 @@ bool ScriptDebugger::_evaluate_watches(int p_stack_level, int p_watch) {
 		//
 		// Also we currently identify vars by their name. In GDScript this doesn't pose an issue since vars must
 		// have a unique name across the whole function, but can be an issue in other languages
-		context = get_expression_context(p_stack_level);
 	}
 
 	bool tracking_watch_changed = false;

--- a/core/script_language.cpp
+++ b/core/script_language.cpp
@@ -615,7 +615,7 @@ ScriptDebugger::ExpressionContext ScriptDebugger::get_expression_context(int p_s
 	List<Variant> vals;
 	List<String> vars;
 
-	if (p_stack_level > 0) {
+	if (p_stack_level >= 0) {
 		context.base = break_lang->debug_get_stack_level_instance(p_stack_level)->get_owner();
 
 		break_lang->debug_get_stack_level_locals(p_stack_level, &vars, &vals);

--- a/core/script_language.cpp
+++ b/core/script_language.cpp
@@ -554,7 +554,12 @@ bool ScriptDebugger::_evaluate_watches(int p_stack_level, int p_watch) {
 	ExpressionContext context;
 
 	if (executing_script) {
-		script_owner_id = lang->debug_get_stack_level_instance(p_stack_level)->get_owner()->get_instance_id();
+		ERR_FAIL_NULL_V(lang, false);
+		ScriptInstance *instance = lang->debug_get_stack_level_instance(p_stack_level);
+		ERR_FAIL_NULL_V(instance, false);
+		Object *owner = instance->get_owner();
+		ERR_FAIL_NULL_V(owner, false);
+		script_owner_id = owner->get_instance_id();
 
 		// We need a way to check whether variable has been declared and initialized already. At the moment,
 		// the `debug_get_stack_level_locals` returns Variant::NIL for the uninitialized vars which is problematic.

--- a/core/script_language.cpp
+++ b/core/script_language.cpp
@@ -31,6 +31,7 @@
 #include "script_language.h"
 
 #include "core/core_string_names.h"
+#include "core/math/expression.h"
 #include "core/project_settings.h"
 
 ScriptLanguage *ScriptServer::_languages[MAX_LANGUAGES];
@@ -414,6 +415,253 @@ void ScriptDebugger::clear_breakpoints() {
 	breakpoints.clear();
 }
 
+void ScriptDebugger::add_watch(int p_stack_level, const String &p_expression) {
+	WatchData watch;
+	watch.expression = memnew(Expression);
+	watch.inverse_stack_level = 0;
+	watch.base_id = 0;
+	watch.result_cache = Variant();
+	watch.tracking = false;
+	watch.locked = false;
+	watch.dirty = false;
+	watch.error = false;
+
+	watches.push_back(watch);
+	set_watch_expression(p_stack_level, watches.size() - 1, p_expression);
+}
+
+void ScriptDebugger::set_watch_expression(int p_stack_level, int p_index, const String &p_expression) {
+	ERR_FAIL_INDEX(p_index, watches.size());
+
+	WatchData &watch = watches.write[p_index];
+	ScriptLanguage *const lang = get_break_language();
+
+	ERR_FAIL_COND(lang->debug_get_stack_level_count() <= 0)
+
+	ExpressionContext context = get_expression_context(p_stack_level);
+
+	if (watch.expression->parse(p_expression, context.input_names) != OK) {
+		watch.error = true;
+	} else {
+		watch.error = false;
+	}
+
+	bool locals_used = watch.expression->get_nodes_by_type(Expression::ENode::TYPE_INPUT).size() > 0;
+	bool members_used = watch.expression->get_nodes_by_type(Expression::ENode::TYPE_SELF).size() > 0;
+
+	if (locals_used) {
+		watch.inverse_stack_level = lang->debug_get_stack_level_count() - p_stack_level - 1;
+	} else {
+		watch.inverse_stack_level = -1;
+	}
+
+	if (members_used) {
+		watch.base_id = lang->debug_get_stack_level_instance(p_stack_level)->get_owner()->get_instance_id();
+	} else {
+		watch.base_id = 0;
+	}
+}
+
+void ScriptDebugger::set_watch_tracking(int p_index, bool p_is_tracking) {
+	ERR_FAIL_INDEX(p_index, watches.size());
+	WatchData &watch = watches.write[p_index];
+
+	watch.tracking = p_is_tracking;
+	if (p_is_tracking) {
+
+		ScriptLanguage *lang = get_break_language();
+
+		watch.base_id = lang->debug_get_stack_level_instance(0)->get_owner()->get_instance_id();
+	}
+}
+
+void ScriptDebugger::set_watch_lock(int p_stack_level, int p_index, bool p_is_locked) {
+	ERR_FAIL_INDEX(p_index, watches.size());
+	WatchData &watch = watches.write[p_index];
+	ScriptLanguage *lang = get_break_language();
+
+	if (lang->debug_get_stack_level_count() != 0) {
+		watch.base_id = lang->debug_get_stack_level_instance(p_stack_level)->get_owner()->get_instance_id();
+	}
+	watch.locked = p_is_locked;
+}
+
+void ScriptDebugger::set_watch_dirty(int p_index, bool p_dirty) {
+	ERR_FAIL_INDEX(p_index, watches.size());
+	watches.write[p_index].dirty = p_dirty;
+}
+
+void ScriptDebugger::remove_watch(int p_index) {
+	ERR_FAIL_INDEX(p_index, watches.size());
+
+	memdelete(watches[p_index].expression);
+	watches.remove(p_index);
+}
+
+void ScriptDebugger::clear_watches() {
+	const int size = watches.size();
+
+	for (int i = 0; i < size; i++) {
+		memdelete(watches[i].expression);
+	}
+	watches.clear();
+}
+
+Variant ScriptDebugger::get_watch_result(int p_index) const {
+	ERR_FAIL_INDEX_V(p_index, watches.size(), Variant());
+
+	return watches[p_index].result_cache;
+}
+
+bool ScriptDebugger::watch_has_error(int p_index) const {
+	ERR_FAIL_INDEX_V(p_index, watches.size(), false);
+
+	return watches[p_index].error;
+}
+
+bool ScriptDebugger::watch_is_dirty(int p_index) const {
+	ERR_FAIL_INDEX_V(p_index, watches.size(), false);
+
+	return watches[p_index].dirty;
+}
+
+String ScriptDebugger::get_watch_error_text(int p_index) const {
+	ERR_FAIL_INDEX_V(p_index, watches.size(), String());
+
+	return watches[p_index].expression->get_error_text();
+}
+
+bool ScriptDebugger::_evaluate_watches(int p_stack_level, int p_watch) {
+	if (watches.size() == 0) {
+		return false;
+	}
+
+	if (evaluate_watches_mutex->try_lock() != OK) {
+		return false;
+	}
+
+	int from = p_watch;
+	int to = p_watch + 1;
+	if (p_watch == -1) {
+		from = 0;
+		to = watches.size();
+	}
+
+	ScriptLanguage *const lang = get_break_language();
+	int inverse_stack_level = lang->debug_get_stack_level_count() - p_stack_level - 1;
+	bool executing_script = lang->debug_get_stack_level_count() > 0;
+	ObjectID script_owner_id = 0;
+	ExpressionContext context;
+
+	if (executing_script) {
+		script_owner_id = lang->debug_get_stack_level_instance(p_stack_level)->get_owner()->get_instance_id();
+
+		// We need a way to check whether variable has been declared and initialized already. At the moment,
+		// the `debug_get_stack_level_locals` returns Variant::NIL for the uninitialized vars which is problematic.
+		// Until this is resolved, tracking watches will not be implemented, because they trigger false alarms.
+		//
+		// Also we currently identify vars by their name. In GDScript this doesn't pose an issue since vars must
+		// have a unique name across the whole function, but can be an issue in other languages
+		context = get_expression_context(p_stack_level);
+	}
+
+	bool tracking_watch_changed = false;
+
+	for (int i = from; i < to; i++) {
+		WatchData &data = watches.write[i];
+		Variant result;
+
+		if (data.inverse_stack_level == -1 || data.inverse_stack_level == inverse_stack_level) {
+			if (data.base_id == 0 || data.base_id == script_owner_id) {
+				result = data.expression->execute(context.input_values, context.base, false);
+			} else {
+				Object *const base = ObjectDB::get_instance(data.base_id);
+
+				if (!base) {
+					continue;
+				}
+				result = data.expression->execute(Array(), base, false);
+			}
+
+			if (data.expression->has_execute_failed()) {
+				data.error = true;
+			} else {
+				data.error = false;
+			}
+		}
+
+		if (result != data.result_cache || data.error) {
+			// Enable this once we implement variable initialization checking
+			/*
+				if (data.tracking) {
+					tracking_watch_changed = true;
+				}
+			*/
+			data.result_cache = result;
+			data.dirty = true;
+		}
+	}
+	evaluate_watches_mutex->unlock();
+
+	return tracking_watch_changed;
+}
+
+ScriptDebugger::ExpressionContext ScriptDebugger::get_expression_context(int p_stack_level) {
+	ERR_FAIL_INDEX_V(p_stack_level, break_lang->debug_get_stack_level_count(), ExpressionContext());
+	ExpressionContext context;
+
+	List<Variant> vals;
+	List<String> vars;
+
+	break_lang->debug_get_stack_level_locals(p_stack_level, &vars, &vals);
+
+	ERR_FAIL_COND_V(vals.size() != vars.size(), ExpressionContext());
+
+	const int size = vals.size();
+
+	if (size > 0) {
+		List<String>::Element *vars_it = vars.front();
+		List<Variant>::Element *vals_it = vals.front();
+		int i = 0;
+
+		context.input_names.resize(size);
+		context.input_values.resize(size);
+
+		do {
+			context.input_names.set(i, vars_it->get());
+			context.input_values.set(i, vals_it->get());
+			vars_it = vars_it->next();
+			vals_it = vals_it->next();
+			++i;
+		} while (vars_it);
+	}
+
+	context.base = break_lang->debug_get_stack_level_instance(p_stack_level)->get_owner();
+
+	return context;
+}
+
+bool ScriptDebugger::evaluate_expression(int p_level, const String &p_expression, String &p_result) {
+	ERR_FAIL_INDEX_V(p_level, break_lang->debug_get_stack_level_count(), false);
+
+	Expression expr;
+	ExpressionContext context = get_expression_context(p_level);
+
+	if (expr.parse(p_expression, context.input_names) == OK) {
+		p_result = expr.execute(context.input_values, context.base);
+		if (expr.has_execute_failed()) {
+			p_result = expr.get_error_text();
+
+			return false;
+		}
+	} else {
+		p_result = expr.get_error_text();
+
+		return false;
+	}
+	return true;
+}
+
 void ScriptDebugger::idle_poll() {
 }
 
@@ -435,6 +683,7 @@ ScriptDebugger::ScriptDebugger() {
 	singleton = this;
 	lines_left = -1;
 	depth = -1;
+	evaluate_watches_mutex = Mutex::create();
 	break_lang = NULL;
 }
 

--- a/core/script_language.cpp
+++ b/core/script_language.cpp
@@ -453,7 +453,8 @@ void ScriptDebugger::set_watch_expression(int p_stack_level, int p_index, const 
 	}
 
 	if (members_used) {
-		watch.base_id = lang->debug_get_stack_level_instance(p_stack_level)->get_owner()->get_instance_id();
+		ScriptInstance *stack_level_instance = lang->debug_get_stack_level_instance(p_stack_level);
+		watch.base_id = stack_level_instance ? stack_level_instance->get_owner()->get_instance_id() : 0;
 	} else {
 		watch.base_id = 0;
 	}

--- a/core/script_language.h
+++ b/core/script_language.h
@@ -324,7 +324,6 @@ public:
 	virtual void debug_get_stack_level_members(int p_level, List<String> *p_members, List<Variant> *p_values, int p_max_subitems = -1, int p_max_depth = -1) = 0;
 	virtual ScriptInstance *debug_get_stack_level_instance(int p_level) { return NULL; }
 	virtual void debug_get_globals(List<String> *p_globals, List<Variant> *p_values, int p_max_subitems = -1, int p_max_depth = -1) = 0;
-	virtual String debug_parse_stack_level_expression(int p_level, const String &p_expression, int p_max_subitems = -1, int p_max_depth = -1) = 0;
 
 	struct StackInfo {
 		String file;
@@ -416,6 +415,8 @@ public:
 	~PlaceHolderScriptInstance();
 };
 
+class Expression;
+
 class ScriptDebugger {
 
 	int lines_left;
@@ -425,6 +426,33 @@ class ScriptDebugger {
 	Map<int, Set<StringName> > breakpoints;
 
 	ScriptLanguage *break_lang;
+
+	Mutex *evaluate_watches_mutex;
+
+protected:
+	struct WatchData {
+		Expression *expression;
+		int inverse_stack_level;
+		ObjectID base_id;
+		Variant result_cache;
+		bool tracking;
+		bool locked;
+		bool dirty;
+		bool error;
+	};
+
+	Vector<WatchData> watches;
+
+	bool _evaluate_watches(int p_stack_level, int p_watch);
+
+	struct ExpressionContext {
+		Object *base;
+		Vector<String> input_names;
+		Array input_values;
+	};
+
+	ExpressionContext get_expression_context(int p_stack_level);
+	bool evaluate_expression(int p_level, const String &p_expression, String &p_result);
 
 public:
 	_FORCE_INLINE_ static ScriptDebugger *get_singleton() { return singleton; }
@@ -441,6 +469,21 @@ public:
 	bool is_breakpoint_line(int p_line) const;
 	void clear_breakpoints();
 	const Map<int, Set<StringName> > &get_breakpoints() const { return breakpoints; }
+
+	void add_watch(int p_stack_level, const String &p_expression);
+	void set_watch_expression(int p_stack_level, int p_index, const String &p_expression);
+	void set_watch_tracking(int p_index, bool p_is_tracking);
+	void set_watch_lock(int p_stack_level, int p_index, bool p_is_locked);
+	void set_watch_dirty(int p_index, bool p_dirty);
+	void remove_watch(int p_index);
+	void clear_watches();
+	int get_watch_count() const { return watches.size(); };
+	Variant get_watch_result(int p_index) const;
+	bool watch_has_error(int p_index) const;
+	bool watch_is_dirty(int p_index) const;
+	String get_watch_error_text(int p_index) const;
+
+	_ALWAYS_INLINE_ bool evaluate_watches(int p_stack_level = 0, int p_watch = -1);
 
 	virtual void debug(ScriptLanguage *p_script, bool p_can_continue = true, bool p_is_error_breakpoint = false) = 0;
 	virtual void idle_poll();
@@ -466,5 +509,13 @@ public:
 	ScriptDebugger();
 	virtual ~ScriptDebugger() { singleton = NULL; }
 };
+
+_ALWAYS_INLINE_ bool ScriptDebugger::evaluate_watches(int p_stack_level, int p_watch) {
+	if (watches.size() == 0) {
+		return false;
+	}
+
+	return _evaluate_watches(p_stack_level, p_watch);
+}
 
 #endif

--- a/core/script_language.h
+++ b/core/script_language.h
@@ -324,6 +324,7 @@ public:
 	virtual void debug_get_stack_level_members(int p_level, List<String> *p_members, List<Variant> *p_values, int p_max_subitems = -1, int p_max_depth = -1) = 0;
 	virtual ScriptInstance *debug_get_stack_level_instance(int p_level) { return NULL; }
 	virtual void debug_get_globals(List<String> *p_globals, List<Variant> *p_values, int p_max_subitems = -1, int p_max_depth = -1) = 0;
+	virtual void debug_get_named_globals(List<String> *p_globals, List<Variant> *p_values) = 0;
 
 	struct StackInfo {
 		String file;

--- a/editor/expression_evaluator.cpp
+++ b/editor/expression_evaluator.cpp
@@ -1,0 +1,284 @@
+/*************************************************************************/
+/*  expression_evaluator.cpp                                             */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "expression_evaluator.h"
+
+#include "core/math/expression.h"
+#include "core/os/input.h"
+#include "core/os/keyboard.h"
+#include "editor/editor_node.h"
+#include "editor/editor_settings.h"
+#include "scene/gui/button.h"
+#include "scene/gui/control.h"
+#include "scene/gui/line_edit.h"
+#include "scene/gui/rich_text_label.h"
+
+class HistoryLineEdit : public Control {
+
+	GDCLASS(HistoryLineEdit, Control);
+
+	struct History {
+		Vector<String> cache;
+		int index;
+	};
+
+	History history;
+	LineEdit *line;
+
+	_ALWAYS_INLINE_ void _text_entered(const String &p_text) {
+		emit_signal("text_entered", p_text);
+	}
+
+protected:
+	static void _bind_methods();
+	void _input(const Ref<InputEvent> &p_event);
+
+public:
+	_ALWAYS_INLINE_ String get_text() const {
+		return line->get_text();
+	}
+
+	_ALWAYS_INLINE_ void set_text(const String &p_text) {
+		line->set_text(p_text);
+	}
+
+	_ALWAYS_INLINE_ void push_history(const String &p_text) {
+		const int sz = history.cache.size();
+
+		if (sz < 2 || history.cache[sz - 2] != p_text) {
+			history.cache.set(sz - 1, p_text);
+			history.cache.push_back("");
+		}
+
+		if (p_text != history.cache[history.index]) {
+			history.index = history.cache.size() - 1;
+		} else if (history.index < history.cache.size() - 1) {
+			++history.index;
+		}
+	}
+
+	_ALWAYS_INLINE_ void clear_history() {
+		history.cache.clear();
+		history.cache.push_back("");
+		history.index = 0;
+	}
+
+	HistoryLineEdit();
+};
+
+void HistoryLineEdit::_input(const Ref<InputEvent> &p_event) {
+	Ref<InputEventKey> k = p_event;
+
+	if (k.is_valid() && k->is_pressed() && line->has_focus()) {
+		if (k->get_scancode() == KEY_UP) {
+			if (history.index > 0) {
+				--history.index;
+			}
+			set_text(history.cache[history.index]);
+			line->set_cursor_position(get_text().size() - 1);
+			accept_event();
+		} else if (k->get_scancode() == KEY_DOWN) {
+			if (history.index < history.cache.size() - 1) {
+				++history.index;
+			}
+			set_text(history.cache[history.index]);
+			line->set_cursor_position(get_text().size() - 1);
+			accept_event();
+		}
+	}
+}
+
+void HistoryLineEdit::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("_input", "event"), &HistoryLineEdit::_input);
+	ClassDB::bind_method(D_METHOD("_text_entered", "text"), &HistoryLineEdit::_text_entered);
+
+	ADD_SIGNAL(MethodInfo("text_entered", PropertyInfo("text")));
+}
+
+HistoryLineEdit::HistoryLineEdit() {
+	history.cache.push_back("");
+	history.index = 0;
+	set_process_input(true);
+
+	Ref<Font> mono_font = EditorNode::get_singleton()->get_gui_base()->get_font("source", "EditorFonts");
+
+	set_h_size_flags(SIZE_EXPAND_FILL);
+
+	line = memnew(LineEdit);
+	add_child(line);
+	line->set_anchors_and_margins_preset(PRESET_WIDE);
+	line->set_context_menu_enabled(false);
+	line->connect("text_entered", this, "_text_entered");
+	line->add_font_override("font", mono_font);
+}
+
+/////////////////////////////////////////////////////////////////////
+
+enum MenuItem {
+	MENU_CLEAR_HISTORY,
+	MENU_CLEAR_LOG
+};
+
+void ExpressionEvaluator::_expression_entered(const String &p_text) {
+	_print_expression(p_text);
+}
+
+void ExpressionEvaluator::_print_pressed() {
+	_print_expression(expression_line->get_text());
+}
+
+void ExpressionEvaluator::_watch_pressed() {
+	emit_signal("add_watch", expression_line->get_text());
+	expression_line->set_text("");
+}
+
+void ExpressionEvaluator::_log_input(const Ref<InputEvent> &p_event) {
+	Ref<InputEventMouseButton> mb = p_event;
+
+	if (mb.is_valid() && mb->is_pressed()) {
+		if (mb->get_button_index() == BUTTON_RIGHT) {
+			Point2 pos = Input::get_singleton()->get_mouse_position();
+
+			menu->set_global_position(pos);
+			menu->set_scale(get_global_transform().get_scale());
+			menu->popup();
+		}
+	}
+}
+
+void ExpressionEvaluator::_menu_item_pressed(int p_id) {
+	const MenuItem item = (MenuItem)p_id;
+
+	switch (item) {
+		case MENU_CLEAR_HISTORY: {
+			expression_line->clear_history();
+		} break;
+
+		case MENU_CLEAR_LOG: {
+			log_label->clear();
+		} break;
+	}
+}
+
+void ExpressionEvaluator::_print_expression(const String &p_text) {
+	if (p_text.empty())
+		return;
+
+	expression_line->push_history(p_text);
+	expression_line->set_text("");
+
+	log_label->add_text(p_text + ":\t");
+
+	if (expression->parse(p_text) != Error::OK) {
+		set_result(expression->get_error_text(), true);
+		return;
+	}
+
+	Object obj;
+	Variant result = expression->execute(Array(), &obj, false);
+
+	if (!expression->has_execute_failed()) {
+		set_result(result.get_construct_string(), false);
+		return;
+	}
+
+	emit_signal("evaluate", p_text, expression->get_error_text());
+}
+
+void ExpressionEvaluator::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("_expression_entered", "text"), &ExpressionEvaluator::_expression_entered);
+	ClassDB::bind_method(D_METHOD("_print_pressed"), &ExpressionEvaluator::_print_pressed);
+	ClassDB::bind_method(D_METHOD("_watch_pressed"), &ExpressionEvaluator::_watch_pressed);
+	ClassDB::bind_method(D_METHOD("_log_input"), &ExpressionEvaluator::_log_input);
+	ClassDB::bind_method(D_METHOD("_menu_item_pressed"), &ExpressionEvaluator::_menu_item_pressed);
+
+	ADD_SIGNAL(MethodInfo("evaluate", PropertyInfo("expression"), PropertyInfo("error_text")));
+	ADD_SIGNAL(MethodInfo("add_watch", PropertyInfo("expression")));
+}
+
+void ExpressionEvaluator::set_result(const String &p_result, bool p_error) {
+	if (p_error) {
+		log_label->push_color(get_color("error_color", "Editor"));
+	}
+
+	log_label->add_text(p_result);
+	log_label->add_newline();
+
+	if (p_error) {
+		log_label->pop();
+	}
+}
+
+ExpressionEvaluator::ExpressionEvaluator() {
+	expression = memnew(Expression);
+
+	Ref<Font> mono_font = EditorNode::get_singleton()->get_gui_base()->get_font("source", "EditorFonts");
+
+	set_name("Expressions");
+	set_focus_mode(FOCUS_NONE);
+
+	log_label = memnew(RichTextLabel);
+	log_label->set_focus_mode(FOCUS_NONE);
+	log_label->set_h_size_flags(SIZE_EXPAND_FILL);
+	log_label->set_v_size_flags(SIZE_EXPAND_FILL);
+	log_label->push_font(mono_font);
+	log_label->set_scroll_follow(true);
+	log_label->connect("gui_input", this, "_log_input");
+	add_child(log_label);
+
+	HBoxContainer *hb = memnew(HBoxContainer);
+	add_child(hb);
+
+	expression_line = memnew(HistoryLineEdit);
+	hb->add_child(expression_line);
+	expression_line->connect("text_entered", this, "_expression_entered");
+
+	Button *print_btn = memnew(Button);
+	print_btn->set_focus_mode(FOCUS_NONE);
+	print_btn->set_text("Print");
+	print_btn->connect("pressed", this, "_print_pressed");
+	hb->add_child(print_btn);
+
+	Button *watch_btn = memnew(Button);
+	watch_btn->set_focus_mode(FOCUS_NONE);
+	watch_btn->set_text("Watch");
+	watch_btn->connect("pressed", this, "_watch_pressed");
+	hb->add_child(watch_btn);
+
+	menu = memnew(PopupMenu);
+	add_child(menu);
+	menu->add_item("Clear History", (int)MENU_CLEAR_HISTORY);
+	menu->add_item("Clear Log", (int)MENU_CLEAR_LOG);
+	menu->connect("id_pressed", this, "_menu_item_pressed");
+}
+
+ExpressionEvaluator::~ExpressionEvaluator() {
+	memdelete(expression);
+}

--- a/editor/expression_evaluator.cpp
+++ b/editor/expression_evaluator.cpp
@@ -250,6 +250,7 @@ ExpressionEvaluator::ExpressionEvaluator() {
 	log_label->set_v_size_flags(SIZE_EXPAND_FILL);
 	log_label->push_font(mono_font);
 	log_label->set_scroll_follow(true);
+	log_label->set_selection_enabled(true);
 	log_label->connect("gui_input", this, "_log_input");
 	add_child(log_label);
 

--- a/editor/expression_evaluator.h
+++ b/editor/expression_evaluator.h
@@ -1,0 +1,70 @@
+/*************************************************************************/
+/*  expression_evaluator.h                                               */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef EXPRESSION_EVALUATOR_H
+#define EXPRESSION_EVALUATOR_H
+
+#include "core/vector.h"
+#include "scene/gui/box_container.h"
+
+class RichTextLabel;
+class LineEdit;
+class PopupMenu;
+class HistoryLineEdit;
+
+class ExpressionEvaluator : public VBoxContainer {
+
+	GDCLASS(ExpressionEvaluator, VBoxContainer);
+
+	RichTextLabel *log_label;
+	HistoryLineEdit *expression_line;
+	PopupMenu *menu;
+
+	Expression *expression;
+
+	void _expression_entered(const String &p_text);
+	void _print_pressed();
+	void _watch_pressed();
+	void _log_input(const Ref<InputEvent> &p_event);
+	void _menu_item_pressed(int p_id);
+
+	void _print_expression(const String &p_text);
+
+protected:
+	static void _bind_methods();
+
+public:
+	void set_result(const String &p_result, bool p_error);
+
+	ExpressionEvaluator();
+	~ExpressionEvaluator();
+};
+
+#endif // EXPRESSION_EVALUATOR_H

--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -2549,6 +2549,17 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 		evaluator->connect("evaluate", this, "_print_expression");
 		evaluator->connect("add_watch", this, "_watch_expression");
 
+		watches = memnew(ScriptWatches(this));
+		watches->set_name("Watches");
+		watches->connect("watch_added", this, "_add_watch");
+		watches->connect("expression_updated", this, "_update_watch_expression");
+		watches->connect("lock_updated", this, "_update_watch_lock");
+		watches->connect("tracking_updated", this, "_update_watch_tracking");
+		watches->connect("watch_removed", this, "_remove_watch");
+		watches->disable(true);
+		debugger_tabs->add_child(watches);
+		refresh_watches_timeout = EDITOR_DEF("debugger/watches_refresh_interval", 0.2);
+
 		server.instance();
 
 		pending_in_queue = 0;
@@ -2558,20 +2569,6 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 		breaked = false;
 
 		tabs->add_child(dbg);
-	}
-
-	{ //watches
-		watches = memnew(ScriptWatches(this));
-		watches->set_name("Watches");
-		watches->connect("watch_added", this, "_add_watch");
-		watches->connect("expression_updated", this, "_update_watch_expression");
-		watches->connect("lock_updated", this, "_update_watch_lock");
-		watches->connect("tracking_updated", this, "_update_watch_tracking");
-		watches->connect("watch_removed", this, "_remove_watch");
-		tabs->add_child(watches);
-
-		watches->disable(true);
-		refresh_watches_timeout = EDITOR_DEF("debugger/watches_refresh_interval", 0.2);
 	}
 
 	{ //errors

--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -498,10 +498,14 @@ bool ScriptEditorDebugger::_execute_expression(const String &p_expression) {
 	ERR_FAIL_COND_V(connection.is_null(), false);
 	ERR_FAIL_COND_V(!connection->is_connected_to_host(), false);
 
-	TreeItem *ti = stack_dump->get_selected();
-	if (!p_expression.empty() && ti) {
-		Dictionary d = ti->get_metadata(0);
-		int frame = d["frame"];
+	if (!p_expression.empty()) {
+		int frame = -1;
+		TreeItem *ti = stack_dump->get_selected();
+		if (ti) {
+			Dictionary d = ti->get_metadata(0);
+			frame = d["frame"];
+		}
+
 		Array msg;
 		msg.push_back("execute_expression");
 		msg.push_back(frame);
@@ -514,7 +518,7 @@ bool ScriptEditorDebugger::_execute_expression(const String &p_expression) {
 }
 
 void ScriptEditorDebugger::_print_expression(const String &p_expression, const String &p_error_text) {
-	if (connection.is_null() || !connection->is_connected_to_host() || !breaked) {
+	if (connection.is_null() || !connection->is_connected_to_host()) {
 		evaluator->set_result(p_error_text, true);
 	} else {
 		if (!_execute_expression(p_expression)) {

--- a/editor/script_editor_debugger.cpp
+++ b/editor/script_editor_debugger.cpp
@@ -33,8 +33,10 @@
 #include "core/io/marshalls.h"
 #include "core/project_settings.h"
 #include "core/ustring.h"
+#include "editor/expression_evaluator.h"
 #include "editor/plugins/canvas_item_editor_plugin.h"
 #include "editor/plugins/spatial_editor_plugin.h"
+#include "editor/script_watches.h"
 #include "editor_log.h"
 #include "editor_network_profiler.h"
 #include "editor_node.h"
@@ -492,6 +494,147 @@ void ScriptEditorDebugger::_video_mem_request() {
 	ppeer->put_var(msg);
 }
 
+bool ScriptEditorDebugger::_execute_expression(const String &p_expression) {
+	ERR_FAIL_COND_V(connection.is_null(), false);
+	ERR_FAIL_COND_V(!connection->is_connected_to_host(), false);
+
+	TreeItem *ti = stack_dump->get_selected();
+	if (!p_expression.empty() && ti) {
+		Dictionary d = ti->get_metadata(0);
+		int frame = d["frame"];
+		Array msg;
+		msg.push_back("execute_expression");
+		msg.push_back(frame);
+		msg.push_back(p_expression);
+		ppeer->put_var(msg);
+
+		return true;
+	}
+	return false;
+}
+
+void ScriptEditorDebugger::_print_expression(const String &p_expression, const String &p_error_text) {
+	if (connection.is_null() || !connection->is_connected_to_host() || !breaked) {
+		evaluator->set_result(p_error_text, true);
+	} else {
+		if (!_execute_expression(p_expression)) {
+			evaluator->set_result(p_error_text, true);
+		}
+	}
+}
+
+void ScriptEditorDebugger::_watch_expression(const String &p_expression) {
+	_add_watch(p_expression);
+	watches->add_watch(p_expression);
+	tabs->set_current_tab(watches->get_index());
+}
+
+void ScriptEditorDebugger::_add_watch(const String &p_expression) {
+
+	ERR_FAIL_COND(connection.is_null());
+	ERR_FAIL_COND(!connection->is_connected_to_host());
+	TreeItem *ti = stack_dump->get_selected();
+	int frame = -1;
+	if (ti) {
+		const Dictionary d = ti->get_metadata(0);
+		frame = d["frame"];
+	}
+	Array msg;
+
+	msg.push_back("add_watch");
+	msg.push_back(frame);
+	msg.push_back(p_expression);
+	ppeer->put_var(msg);
+}
+
+void ScriptEditorDebugger::_update_watch_expression(int p_index, const String &p_expression) {
+
+	ERR_FAIL_COND(connection.is_null());
+	ERR_FAIL_COND(!connection->is_connected_to_host());
+	TreeItem *ti = stack_dump->get_selected();
+	int frame = -1;
+	if (ti) {
+		const Dictionary d = ti->get_metadata(0);
+		frame = d["frame"];
+	}
+	Array msg;
+
+	msg.push_back("watch_expression");
+	msg.push_back(frame);
+	msg.push_back(p_index);
+	msg.push_back(p_expression);
+	ppeer->put_var(msg);
+}
+
+void ScriptEditorDebugger::_update_watch_lock(int p_index, bool p_is_locked) {
+	ERR_FAIL_COND(connection.is_null());
+	ERR_FAIL_COND(!connection->is_connected_to_host());
+	TreeItem *ti = stack_dump->get_selected();
+
+	ERR_FAIL_NULL_MSG(ti, "Can't lock watch if execution didn't break.");
+
+	const Dictionary d = ti->get_metadata(0);
+	const int frame = d["frame"];
+
+	Array msg;
+
+	msg.push_back("watch_lock");
+	msg.push_back(frame);
+	msg.push_back(p_index);
+	msg.push_back(p_is_locked);
+	ppeer->put_var(msg);
+}
+
+void ScriptEditorDebugger::_update_watch_tracking(int p_index, bool p_is_tracked) {
+	ERR_FAIL_COND(connection.is_null());
+	ERR_FAIL_COND(!connection->is_connected_to_host());
+
+	Array msg;
+	msg.push_back("watch_tracking");
+	msg.push_back(p_index);
+	msg.push_back(p_is_tracked);
+	ppeer->put_var(msg);
+}
+
+void ScriptEditorDebugger::_remove_watch(int p_index) {
+
+	ERR_FAIL_COND(connection.is_null());
+	ERR_FAIL_COND(!connection->is_connected_to_host());
+
+	Array msg;
+	msg.push_back("remove_watch");
+	msg.push_back(p_index);
+	ppeer->put_var(msg);
+}
+
+void ScriptEditorDebugger::_request_watches_evaluation(int p_stack_level) {
+	ERR_FAIL_COND(connection.is_null());
+	ERR_FAIL_COND(!connection->is_connected_to_host());
+
+	Array msg;
+	msg.push_back("eval_watches");
+	msg.push_back(p_stack_level);
+	ppeer->put_var(msg);
+}
+
+void ScriptEditorDebugger::_sync_watches() {
+	const int watch_count = watches->get_watch_count();
+
+	for (int i = 0; i < watch_count; ++i) {
+		const String &expr = watches->get_watch_expression(i);
+		_add_watch(expr);
+	}
+}
+
+void ScriptEditorDebugger::_refresh_watches() {
+	ERR_FAIL_COND(connection.is_null());
+	ERR_FAIL_COND(!connection->is_connected_to_host());
+
+	Array msg;
+	msg.push_back("refresh_watches");
+	ppeer->put_var(msg);
+}
+
 Size2 ScriptEditorDebugger::get_minimum_size() const {
 
 	Size2 ms = MarginContainer::get_minimum_size();
@@ -689,6 +832,24 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 		vmem_total->set_tooltip(TTR("Bytes:") + " " + itos(total));
 		vmem_total->set_text(String::humanize_size(total));
 
+	} else if (p_msg == "message:expression_result") {
+		bool success = p_data[0];
+		const String &result = p_data[1];
+
+		evaluator->set_result(result, !success);
+
+	} else if (p_msg == "message:watch_update") {
+		bool success = p_data[0];
+		int index = p_data[1];
+		const String &result = p_data[2];
+		watches->update_watch_result(index, result, success);
+	} else if (p_msg == "message:watch_remove") {
+		int index = p_data[0];
+
+		watches->remove_watch(index);
+	} else if (p_msg == "tracking_watches_changed") {
+		Vector<int> watch_indices = p_data[1];
+		tabs->set_current_tab(watches->get_index());
 	} else if (p_msg == "stack_dump") {
 
 		stack_dump->clear();
@@ -1090,6 +1251,8 @@ void ScriptEditorDebugger::_parse_message(const String &p_msg, const Array &p_da
 		network_profiler->set_bandwidth(p_data[0], p_data[1]);
 	} else if (p_msg == "kill_me") {
 
+		debugger_tabs->set_current_tab(0);
+		watches->disable(true);
 		editor->call_deferred("stop_child_process");
 	}
 }
@@ -1272,6 +1435,14 @@ void ScriptEditorDebugger::_notification(int p_what) {
 					msg.push_back(cam->get_zfar());
 					ppeer->put_var(msg);
 				}
+
+				if (watches->get_watch_count() > 0) {
+					refresh_watches_timeout -= get_process_delta_time();
+					if (refresh_watches_timeout < 0) {
+						refresh_watches_timeout = EditorSettings::get_singleton()->get("debugger/watches_refresh_interval");
+						_refresh_watches();
+					}
+				}
 			}
 
 			if (error_count != last_error_count || warning_count != last_warning_count) {
@@ -1333,6 +1504,8 @@ void ScriptEditorDebugger::_notification(int p_what) {
 					EditorNode::get_singleton()->get_pause_button()->set_disabled(false);
 
 					update_live_edit_root();
+					_sync_watches();
+					watches->disable(false);
 					if (profiler->is_profiling()) {
 						_profiler_activate(true);
 					}
@@ -1530,6 +1703,8 @@ void ScriptEditorDebugger::stop() {
 	EditorNode::get_singleton()->get_pause_button()->set_disabled(true);
 	EditorNode::get_singleton()->get_scene_tree_dock()->hide_remote_tree();
 	EditorNode::get_singleton()->get_scene_tree_dock()->hide_tab_buttons();
+	debugger_tabs->set_current_tab(0);
+	watches->disable(true);
 
 	if (hide_on_stop) {
 		if (is_visible_in_tree())
@@ -1611,6 +1786,8 @@ void ScriptEditorDebugger::_stack_dump_frame_selected() {
 	} else {
 		inspector->edit(NULL);
 	}
+
+	_request_watches_evaluation(d["frame"]);
 }
 
 void ScriptEditorDebugger::_output_clear() {
@@ -2204,6 +2381,14 @@ void ScriptEditorDebugger::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("_performance_select"), &ScriptEditorDebugger::_performance_select);
 	ClassDB::bind_method(D_METHOD("_scene_tree_request"), &ScriptEditorDebugger::_scene_tree_request);
 	ClassDB::bind_method(D_METHOD("_video_mem_request"), &ScriptEditorDebugger::_video_mem_request);
+	ClassDB::bind_method(D_METHOD("_execute_expression"), &ScriptEditorDebugger::_execute_expression);
+	ClassDB::bind_method(D_METHOD("_print_expression"), &ScriptEditorDebugger::_print_expression);
+	ClassDB::bind_method(D_METHOD("_watch_expression"), &ScriptEditorDebugger::_watch_expression);
+	ClassDB::bind_method(D_METHOD("_add_watch"), &ScriptEditorDebugger::_add_watch);
+	ClassDB::bind_method(D_METHOD("_update_watch_expression", "index", "expression"), &ScriptEditorDebugger::_update_watch_expression);
+	ClassDB::bind_method(D_METHOD("_update_watch_lock", "index", "is_locked"), &ScriptEditorDebugger::_update_watch_lock);
+	ClassDB::bind_method(D_METHOD("_update_watch_tracking", "index", "is_tracked"), &ScriptEditorDebugger::_update_watch_tracking);
+	ClassDB::bind_method(D_METHOD("_remove_watch", "watch_index"), &ScriptEditorDebugger::_remove_watch);
 	ClassDB::bind_method(D_METHOD("_live_edit_set"), &ScriptEditorDebugger::_live_edit_set);
 	ClassDB::bind_method(D_METHOD("_live_edit_clear"), &ScriptEditorDebugger::_live_edit_clear);
 
@@ -2264,7 +2449,6 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 	{ //debugger
 		VBoxContainer *vbc = memnew(VBoxContainer);
 		vbc->set_name(TTR("Debugger"));
-		//tabs->add_child(vbc);
 		Control *dbg = vbc;
 
 		HBoxContainer *hbc = memnew(HBoxContainer);
@@ -2344,12 +2528,22 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 		stack_dump->connect("cell_selected", this, "_stack_dump_frame_selected");
 		sc->add_child(stack_dump);
 
+		debugger_tabs = memnew(TabContainer);
+		debugger_tabs->set_h_size_flags(SIZE_EXPAND_FILL);
+		sc->add_child(debugger_tabs);
+
 		inspector = memnew(EditorInspector);
 		inspector->set_h_size_flags(SIZE_EXPAND_FILL);
+		inspector->set_name("Variables");
 		inspector->set_enable_capitalize_paths(false);
 		inspector->set_read_only(true);
 		inspector->connect("object_id_selected", this, "_scene_tree_property_select_object");
-		sc->add_child(inspector);
+		debugger_tabs->add_child(inspector);
+
+		evaluator = memnew(ExpressionEvaluator);
+		debugger_tabs->add_child(evaluator);
+		evaluator->connect("evaluate", this, "_print_expression");
+		evaluator->connect("add_watch", this, "_watch_expression");
 
 		server.instance();
 
@@ -2360,6 +2554,20 @@ ScriptEditorDebugger::ScriptEditorDebugger(EditorNode *p_editor) {
 		breaked = false;
 
 		tabs->add_child(dbg);
+	}
+
+	{ //watches
+		watches = memnew(ScriptWatches(this));
+		watches->set_name("Watches");
+		watches->connect("watch_added", this, "_add_watch");
+		watches->connect("expression_updated", this, "_update_watch_expression");
+		watches->connect("lock_updated", this, "_update_watch_lock");
+		watches->connect("tracking_updated", this, "_update_watch_tracking");
+		watches->connect("watch_removed", this, "_remove_watch");
+		tabs->add_child(watches);
+
+		watches->disable(true);
+		refresh_watches_timeout = EDITOR_DEF("debugger/watches_refresh_interval", 0.2);
 	}
 
 	{ //errors

--- a/editor/script_editor_debugger.h
+++ b/editor/script_editor_debugger.h
@@ -52,6 +52,8 @@ class HSplitContainer;
 class ItemList;
 class EditorProfiler;
 class EditorNetworkProfiler;
+class ExpressionEvaluator;
+class ScriptWatches;
 
 class ScriptEditorDebuggerInspectedObject;
 
@@ -154,7 +156,11 @@ private:
 	LineEdit *vmem_total;
 
 	Tree *stack_dump;
+	TabContainer *debugger_tabs;
 	EditorInspector *inspector;
+	ExpressionEvaluator *evaluator;
+	ScriptWatches *watches;
+	float refresh_watches_timeout;
 
 	Ref<TCP_Server> server;
 	Ref<StreamPeerTCP> connection;
@@ -196,6 +202,18 @@ private:
 	int _update_scene_tree(TreeItem *parent, const Array &nodes, int current_index);
 
 	void _video_mem_request();
+
+	bool _execute_expression(const String &p_expression);
+	void _print_expression(const String &p_expression, const String &p_error_text);
+	void _watch_expression(const String &p_expression);
+	void _add_watch(const String &p_expression);
+	void _update_watch_expression(int p_index, const String &p_expression);
+	void _update_watch_lock(int p_index, bool p_is_locked);
+	void _update_watch_tracking(int p_index, bool p_is_tracking);
+	void _remove_watch(int p_index);
+	void _request_watches_evaluation(int p_stack_level);
+	void _sync_watches();
+	void _refresh_watches();
 
 	int _get_node_path_cache(const NodePath &p_path);
 

--- a/editor/script_watches.cpp
+++ b/editor/script_watches.cpp
@@ -1,0 +1,339 @@
+/*************************************************************************/
+/*  script_watches.cpp                                                   */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#include "script_watches.h"
+
+#include "core/math/expression.h"
+#include "editor/script_editor_debugger.h"
+#include "scene/gui/box_container.h"
+#include "scene/gui/check_box.h"
+#include "scene/gui/label.h"
+#include "scene/gui/line_edit.h"
+#include "scene/gui/rich_text_label.h"
+#include "scene/gui/tool_button.h"
+
+class ScriptWatch : public HBoxContainer {
+
+	GDCLASS(ScriptWatch, HBoxContainer);
+
+	void _expression_entered(const String &p_new_expression) {
+		expression_line->release_focus();
+	}
+
+	void _expression_changed(const String &p_new_expression) {
+		emit_signal("expression_changed", this);
+	}
+
+	void _lock_pressed(bool p_locked) {
+		emit_signal("lock_changed", this, p_locked);
+	}
+
+	void _track_pressed(bool p_tracking) {
+		emit_signal("tracking_changed", this, p_tracking);
+	}
+
+	void _remove_pressed() {
+		emit_signal("watch_removed", this);
+	}
+
+	void _expression_lost_focus() {
+		emit_signal("focus_lost", this);
+	}
+
+protected:
+	static void _bind_methods() {
+		ClassDB::bind_method(D_METHOD("_expression_entered", "new_expression"), &ScriptWatch::_expression_entered);
+		ClassDB::bind_method(D_METHOD("_expression_changed", "new_expression"), &ScriptWatch::_expression_changed);
+		ClassDB::bind_method(D_METHOD("_lock_pressed"), &ScriptWatch::_lock_pressed);
+		ClassDB::bind_method(D_METHOD("_track_pressed"), &ScriptWatch::_track_pressed);
+		ClassDB::bind_method(D_METHOD("_remove_pressed"), &ScriptWatch::_remove_pressed);
+		ClassDB::bind_method(D_METHOD("_expression_lost_focus"), &ScriptWatch::_expression_lost_focus);
+
+		ADD_SIGNAL(MethodInfo("expression_changed", PropertyInfo(Variant::OBJECT, "watch")));
+		ADD_SIGNAL(MethodInfo("lock_changed", PropertyInfo(Variant::OBJECT, "watch"), PropertyInfo(Variant::BOOL, "locked")));
+		ADD_SIGNAL(MethodInfo("tracking_changed", PropertyInfo(Variant::OBJECT, "watch"), PropertyInfo(Variant::BOOL, "tracking")));
+		ADD_SIGNAL(MethodInfo("watch_removed", PropertyInfo(Variant::OBJECT, "watch")));
+		ADD_SIGNAL(MethodInfo("focus_lost", PropertyInfo(Variant::OBJECT, "watch")));
+	}
+
+	void _notification(int p_what) {
+		switch (p_what) {
+			case NOTIFICATION_ENTER_TREE:
+				remove_button->set_icon(get_icon("Remove", "EditorIcons"));
+				lock_toggle->add_icon_override("checked", get_icon("Lock", "EditorIcons"));
+				lock_toggle->add_icon_override("unchecked", get_icon("Unlock", "EditorIcons"));
+		}
+	}
+
+public:
+	Label *id_label;
+	LineEdit *expression_line;
+	RichTextLabel *result_label;
+	CheckBox *lock_toggle;
+	CheckBox *track_toggle;
+	ToolButton *remove_button;
+	int id;
+
+	void set_id(int p_watch_id) {
+		id = p_watch_id;
+		id_label->set_text(("#" + itos(p_watch_id).lpad(2, "0")));
+	}
+
+	void set_result(const String &result, bool success) {
+		if (success) {
+			result_label->set_text(result);
+		} else {
+			result_label->clear();
+			result_label->push_color(get_color("error_color", "Editor"));
+			result_label->add_text(result);
+			result_label->pop();
+		}
+	}
+
+	void disable(bool p_disable) {
+		Control::FocusMode focus;
+		if (p_disable) {
+			focus = FOCUS_NONE;
+		} else {
+			focus = FOCUS_ALL;
+		}
+
+		expression_line->set_editable(!p_disable);
+		expression_line->set_focus_mode(focus);
+		lock_toggle->set_disabled(p_disable);
+		track_toggle->set_disabled(p_disable);
+	}
+
+	ScriptWatch(int p_watch_id) {
+		id_label = memnew(Label);
+		id_label->set_text(("#" + itos(p_watch_id).lpad(2, "0")));
+		add_child(id_label);
+
+		expression_line = memnew(LineEdit);
+		expression_line->set_placeholder("Enter expression...");
+		expression_line->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		expression_line->connect("text_entered", this, "_expression_entered");
+		expression_line->connect("text_changed", this, "_expression_changed");
+		expression_line->connect("focus_exited", this, "_expression_lost_focus");
+		add_child(expression_line);
+
+		result_label = memnew(RichTextLabel);
+		result_label->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+		result_label->set_scroll_active(false);
+		add_child(result_label);
+
+		lock_toggle = memnew(CheckBox);
+		lock_toggle->set_focus_mode(FOCUS_NONE);
+		lock_toggle->connect("toggled", this, "_lock_pressed");
+		add_child(lock_toggle);
+
+		track_toggle = memnew(CheckBox);
+		track_toggle->set_focus_mode(FOCUS_NONE);
+		track_toggle->set_visible(false); // Feature disabled temporarily
+		track_toggle->connect("toggled", this, "_track_pressed");
+		add_child(track_toggle);
+
+		remove_button = memnew(ToolButton);
+		remove_button->set_icon(get_icon("Error", "EditorIcons"));
+		remove_button->connect("pressed", this, "_remove_pressed");
+		add_child(remove_button);
+
+		this->id = p_watch_id;
+	}
+};
+
+void ScriptWatches::_watch_changed(Object *p_watch) {
+
+	ScriptWatch *w = cast_to<ScriptWatch>(p_watch);
+	const String &new_expression = w->expression_line->get_text();
+
+	if (!new_expression.empty()) {
+		if (p_watch == watches[watches.size() - 1]) {
+			add_watch(new_expression);
+
+			const int length = w->expression_line->get_text().length();
+			w->expression_line->set_cursor_position(length);
+
+			emit_signal("watch_added", "");
+		}
+	}
+}
+
+void ScriptWatches::_lock_changed(Object *p_watch, bool p_locked) {
+	ScriptWatch *w = cast_to<ScriptWatch>(p_watch);
+
+	emit_signal("lock_updated", w->id - 1, p_locked);
+}
+
+void ScriptWatches::_tracking_changed(Object *p_watch, bool p_tracking) {
+	ScriptWatch *w = cast_to<ScriptWatch>(p_watch);
+
+	emit_signal("tracking_updated", w->id - 1, p_tracking);
+}
+
+void ScriptWatches::_watch_removed(Object *p_watch) {
+	const int num_watches = watches.size();
+	ScriptWatch *w = cast_to<ScriptWatch>(p_watch);
+
+	if (watches[num_watches - 1] != w) {
+		_remove_watch(w);
+		emit_signal("watch_removed", w->id - 1);
+	}
+}
+
+void ScriptWatches::_lost_focus(Object *p_watch) {
+	if (p_watch != _get_watch_ghost()) {
+		ScriptWatch *w = cast_to<ScriptWatch>(p_watch);
+		const String &expr = w->expression_line->get_text();
+
+		emit_signal("expression_updated", w->id - 1, expr);
+		if (w->lock_toggle->is_pressed()) {
+			w->lock_toggle->set_pressed(false);
+			_lock_changed(p_watch, false);
+		}
+	}
+}
+
+void ScriptWatches::_breaked(bool p_breaked, bool p_can_debug) {
+	for (int i = 0; i < get_watch_count(); ++i) {
+		watches[i]->lock_toggle->set_disabled(!p_breaked);
+	}
+}
+
+void ScriptWatches::_bind_methods() {
+	ClassDB::bind_method(D_METHOD("_watch_changed", "watch"), &ScriptWatches::_watch_changed);
+	ClassDB::bind_method(D_METHOD("_lock_changed", "watch"), &ScriptWatches::_lock_changed);
+	ClassDB::bind_method(D_METHOD("_tracking_changed", "watch"), &ScriptWatches::_tracking_changed);
+	ClassDB::bind_method(D_METHOD("_watch_removed", "watch"), &ScriptWatches::_watch_removed);
+	ClassDB::bind_method(D_METHOD("_breaked", "p_breaked", "p_can_debug"), &ScriptWatches::_breaked);
+	ClassDB::bind_method(D_METHOD("_lost_focus", "p_watch"), &ScriptWatches::_lost_focus);
+
+	ADD_SIGNAL(MethodInfo("watch_added"));
+	ADD_SIGNAL(MethodInfo("expression_updated", PropertyInfo(Variant::INT, "watch_index"), PropertyInfo(Variant::STRING, "new_expression")));
+	ADD_SIGNAL(MethodInfo("lock_updated", PropertyInfo(Variant::INT, "watch_index"), PropertyInfo(Variant::BOOL, "locked")));
+	ADD_SIGNAL(MethodInfo("tracking_updated", PropertyInfo(Variant::INT, "watch_index"), PropertyInfo(Variant::BOOL, "tracking")));
+	ADD_SIGNAL(MethodInfo("watch_removed", PropertyInfo(Variant::INT, "watch_index")));
+}
+
+ScriptWatch *ScriptWatches::_get_watch_ghost() const {
+	ERR_FAIL_COND_V_MSG(watches.size() == 0, NULL, "No watch ghost found!");
+	return watches[watches.size() - 1];
+}
+
+void ScriptWatches::_create_watch_ghost() {
+	ScriptWatch *watch = memnew(ScriptWatch(watches.size() + 1));
+	watch->connect("watch_removed", this, "_watch_removed");
+	watch->connect("expression_changed", this, "_watch_changed");
+	watch->connect("lock_changed", this, "_lock_changed");
+	watch->connect("tracking_changed", this, "_tracking_changed");
+	watch->connect("focus_lost", this, "_lost_focus");
+	main_vbox->add_child(watch);
+	watches.push_back(watch);
+
+	watch->lock_toggle->set_disabled(true);
+	watch->track_toggle->set_disabled(true);
+}
+
+void ScriptWatches::_remove_watch(ScriptWatch *p_watch) {
+	int id = p_watch->id;
+
+	watches.remove(id - 1);
+	memdelete(p_watch);
+	_update_watch_ids(id - 1);
+}
+
+void ScriptWatches::_update_watch_ids(int p_from_index) {
+	const int size = watches.size();
+
+	for (int i = p_from_index; i < size; i++) {
+		watches[i]->set_id(i + 1);
+	}
+}
+
+void ScriptWatches::add_watch(const String &p_expression) {
+	const int index = get_watch_count();
+
+	_create_watch_ghost();
+	watches[index]->lock_toggle->set_disabled(false);
+	watches[index]->track_toggle->set_disabled(false);
+	watches[index]->expression_line->set_text(p_expression);
+}
+
+void ScriptWatches::update_watch_result(int p_index, const String &p_result, bool p_success) {
+	ERR_FAIL_INDEX(p_index, watches.size());
+	ScriptWatch *watch = watches[p_index];
+
+	watch->set_result(p_result, p_success);
+}
+
+void ScriptWatches::remove_watch(int p_index) {
+	ERR_FAIL_INDEX(p_index, watches.size());
+	ScriptWatch *watch = watches[p_index];
+
+	_remove_watch(watch);
+}
+
+int ScriptWatches::get_watch_count() const {
+	// Minus one because there's always one extra "ghost" watch
+	return watches.size() - 1;
+}
+
+String ScriptWatches::get_watch_expression(int p_index) {
+	ERR_FAIL_INDEX_V(p_index, watches.size(), String());
+
+	return watches[p_index]->expression_line->get_text();
+}
+
+void ScriptWatches::disable(bool p_disable) {
+	for (int i = 0; i < get_watch_count(); i++) {
+		watches[i]->disable(p_disable);
+	}
+
+	ScriptWatch *const w = _get_watch_ghost();
+
+	Control::FocusMode focus;
+	if (p_disable) {
+		focus = FOCUS_NONE;
+	} else {
+		focus = FOCUS_ALL;
+	}
+	w->expression_line->set_editable(!p_disable);
+	w->expression_line->set_focus_mode(focus);
+}
+
+ScriptWatches::ScriptWatches(ScriptEditorDebugger *p_debugger) {
+	main_vbox = memnew(VBoxContainer);
+	main_vbox->set_h_size_flags(Control::SIZE_EXPAND_FILL);
+	main_vbox->set_v_size_flags(Control::SIZE_EXPAND_FILL);
+	_create_watch_ghost();
+	add_child(main_vbox);
+
+	p_debugger->call_deferred("connect", "breaked", this, "_breaked");
+}

--- a/editor/script_watches.cpp
+++ b/editor/script_watches.cpp
@@ -265,7 +265,7 @@ void ScriptWatches::_remove_watch(ScriptWatch *p_watch) {
 	int id = p_watch->id;
 
 	watches.remove(id - 1);
-	memdelete(p_watch);
+	p_watch->queue_delete();
 	_update_watch_ids(id - 1);
 }
 

--- a/editor/script_watches.h
+++ b/editor/script_watches.h
@@ -1,0 +1,83 @@
+/*************************************************************************/
+/*  script_watches.h                                                     */
+/*************************************************************************/
+/*                       This file is part of:                           */
+/*                           GODOT ENGINE                                */
+/*                      https://godotengine.org                          */
+/*************************************************************************/
+/* Copyright (c) 2007-2019 Juan Linietsky, Ariel Manzur.                 */
+/* Copyright (c) 2014-2019 Godot Engine contributors (cf. AUTHORS.md)    */
+/*                                                                       */
+/* Permission is hereby granted, free of charge, to any person obtaining */
+/* a copy of this software and associated documentation files (the       */
+/* "Software"), to deal in the Software without restriction, including   */
+/* without limitation the rights to use, copy, modify, merge, publish,   */
+/* distribute, sublicense, and/or sell copies of the Software, and to    */
+/* permit persons to whom the Software is furnished to do so, subject to */
+/* the following conditions:                                             */
+/*                                                                       */
+/* The above copyright notice and this permission notice shall be        */
+/* included in all copies or substantial portions of the Software.       */
+/*                                                                       */
+/* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,       */
+/* EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF    */
+/* MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.*/
+/* IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY  */
+/* CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,  */
+/* TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE     */
+/* SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.                */
+/*************************************************************************/
+
+#ifndef SCRIPT_WATCHES_H
+#define SCRIPT_WATCHES_H
+
+#include "scene/gui/box_container.h"
+#include "scene/gui/scroll_container.h"
+
+class VBoxContainer;
+class HBoxContainer;
+class LineEdit;
+class RichTextLabel;
+class CheckBox;
+class ToolButton;
+
+class ScriptWatch;
+class ScriptEditorDebugger;
+
+class ScriptWatches : public ScrollContainer {
+
+	GDCLASS(ScriptWatches, ScrollContainer)
+private:
+	VBoxContainer *main_vbox;
+
+	Vector<ScriptWatch *> watches;
+
+	void _watch_changed(Object *p_watch);
+	void _lock_changed(Object *p_watch, bool p_locked);
+	void _tracking_changed(Object *p_watch, bool p_tracking);
+	void _watch_removed(Object *p_watch);
+	void _lost_focus(Object *p_watch);
+	void _breaked(bool p_breaked, bool p_can_debug);
+
+	ScriptWatch *_get_watch_ghost() const;
+	void _create_watch_ghost();
+	void _remove_watch(ScriptWatch *p_watch);
+	void _update_watch_ids(int p_from_index = 0);
+
+protected:
+	static void _bind_methods();
+
+public:
+	void add_watch(const String &p_expression);
+	void update_watch_result(int p_index, const String &result, bool success);
+	void remove_watch(int p_index);
+
+	int get_watch_count() const;
+	String get_watch_expression(int p_index);
+
+	void disable(bool p_disable);
+
+	ScriptWatches(ScriptEditorDebugger *p_debugger);
+};
+
+#endif // SCRIPT_WATCHES_H

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -1675,6 +1675,7 @@ bool Main::start() {
 					if (global_var) {
 						for (int i = 0; i < ScriptServer::get_language_count(); i++) {
 							ScriptServer::get_language(i)->add_global_constant(name, Variant());
+							ScriptServer::get_language(i)->add_named_global_constant(name, Variant());
 						}
 					}
 				}
@@ -1723,6 +1724,7 @@ bool Main::start() {
 					if (global_var) {
 						for (int i = 0; i < ScriptServer::get_language_count(); i++) {
 							ScriptServer::get_language(i)->add_global_constant(name, n);
+							ScriptServer::get_language(i)->add_named_global_constant(name, n);
 						}
 					}
 				}

--- a/modules/gdnative/nativescript/nativescript.cpp
+++ b/modules/gdnative/nativescript/nativescript.cpp
@@ -1161,6 +1161,8 @@ void NativeScriptLanguage::debug_get_stack_level_members(int p_level, List<Strin
 }
 void NativeScriptLanguage::debug_get_globals(List<String> *p_locals, List<Variant> *p_values, int p_max_subitems, int p_max_depth) {
 }
+void NativeScriptLanguage::debug_get_named_globals(List<String> *p_locals, List<Variant> *p_values) {
+}
 // Debugging stuff end.
 
 void NativeScriptLanguage::reload_all_scripts() {

--- a/modules/gdnative/nativescript/nativescript.cpp
+++ b/modules/gdnative/nativescript/nativescript.cpp
@@ -1161,9 +1161,6 @@ void NativeScriptLanguage::debug_get_stack_level_members(int p_level, List<Strin
 }
 void NativeScriptLanguage::debug_get_globals(List<String> *p_locals, List<Variant> *p_values, int p_max_subitems, int p_max_depth) {
 }
-String NativeScriptLanguage::debug_parse_stack_level_expression(int p_level, const String &p_expression, int p_max_subitems, int p_max_depth) {
-	return "";
-}
 // Debugging stuff end.
 
 void NativeScriptLanguage::reload_all_scripts() {

--- a/modules/gdnative/nativescript/nativescript.h
+++ b/modules/gdnative/nativescript/nativescript.h
@@ -334,6 +334,7 @@ public:
 	virtual void debug_get_stack_level_locals(int p_level, List<String> *p_locals, List<Variant> *p_values, int p_max_subitems, int p_max_depth);
 	virtual void debug_get_stack_level_members(int p_level, List<String> *p_members, List<Variant> *p_values, int p_max_subitems, int p_max_depth);
 	virtual void debug_get_globals(List<String> *p_locals, List<Variant> *p_values, int p_max_subitems, int p_max_depth);
+	virtual void debug_get_named_globals(List<String> *p_locals, List<Variant> *p_values);
 	virtual void reload_all_scripts();
 	virtual void reload_tool_script(const Ref<Script> &p_script, bool p_soft_reload);
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;

--- a/modules/gdnative/nativescript/nativescript.h
+++ b/modules/gdnative/nativescript/nativescript.h
@@ -334,7 +334,6 @@ public:
 	virtual void debug_get_stack_level_locals(int p_level, List<String> *p_locals, List<Variant> *p_values, int p_max_subitems, int p_max_depth);
 	virtual void debug_get_stack_level_members(int p_level, List<String> *p_members, List<Variant> *p_values, int p_max_subitems, int p_max_depth);
 	virtual void debug_get_globals(List<String> *p_locals, List<Variant> *p_values, int p_max_subitems, int p_max_depth);
-	virtual String debug_parse_stack_level_expression(int p_level, const String &p_expression, int p_max_subitems, int p_max_depth);
 	virtual void reload_all_scripts();
 	virtual void reload_tool_script(const Ref<Script> &p_script, bool p_soft_reload);
 	virtual void get_recognized_extensions(List<String> *p_extensions) const;

--- a/modules/gdnative/pluginscript/pluginscript_language.cpp
+++ b/modules/gdnative/pluginscript/pluginscript_language.cpp
@@ -377,6 +377,9 @@ void PluginScriptLanguage::debug_get_globals(List<String> *p_locals, List<Varian
 	}
 }
 
+void PluginScriptLanguage::debug_get_named_globals(List<String> *p_globals, List<Variant> *p_values) {
+}
+
 void PluginScriptLanguage::reload_all_scripts() {
 	// TODO
 }

--- a/modules/gdnative/pluginscript/pluginscript_language.cpp
+++ b/modules/gdnative/pluginscript/pluginscript_language.cpp
@@ -377,16 +377,6 @@ void PluginScriptLanguage::debug_get_globals(List<String> *p_locals, List<Varian
 	}
 }
 
-String PluginScriptLanguage::debug_parse_stack_level_expression(int p_level, const String &p_expression, int p_max_subitems, int p_max_depth) {
-	if (_desc.debug_parse_stack_level_expression) {
-		godot_string tmp = _desc.debug_parse_stack_level_expression(_data, p_level, (godot_string *)&p_expression, p_max_subitems, p_max_depth);
-		String ret = *(String *)&tmp;
-		godot_string_destroy(&tmp);
-		return ret;
-	}
-	return String("Nothing");
-}
-
 void PluginScriptLanguage::reload_all_scripts() {
 	// TODO
 }

--- a/modules/gdnative/pluginscript/pluginscript_language.h
+++ b/modules/gdnative/pluginscript/pluginscript_language.h
@@ -101,7 +101,6 @@ public:
 	virtual void debug_get_stack_level_locals(int p_level, List<String> *p_locals, List<Variant> *p_values, int p_max_subitems = -1, int p_max_depth = -1);
 	virtual void debug_get_stack_level_members(int p_level, List<String> *p_members, List<Variant> *p_values, int p_max_subitems = -1, int p_max_depth = -1);
 	virtual void debug_get_globals(List<String> *p_locals, List<Variant> *p_values, int p_max_subitems = -1, int p_max_depth = -1);
-	virtual String debug_parse_stack_level_expression(int p_level, const String &p_expression, int p_max_subitems = -1, int p_max_depth = -1);
 
 	// virtual Vector<StackInfo> debug_get_current_stack_info() { return Vector<StackInfo>(); }
 

--- a/modules/gdnative/pluginscript/pluginscript_language.h
+++ b/modules/gdnative/pluginscript/pluginscript_language.h
@@ -101,6 +101,7 @@ public:
 	virtual void debug_get_stack_level_locals(int p_level, List<String> *p_locals, List<Variant> *p_values, int p_max_subitems = -1, int p_max_depth = -1);
 	virtual void debug_get_stack_level_members(int p_level, List<String> *p_members, List<Variant> *p_values, int p_max_subitems = -1, int p_max_depth = -1);
 	virtual void debug_get_globals(List<String> *p_locals, List<Variant> *p_values, int p_max_subitems = -1, int p_max_depth = -1);
+	virtual void debug_get_named_globals(List<String> *p_globals, List<Variant> *p_values);
 
 	// virtual Vector<StackInfo> debug_get_current_stack_info() { return Vector<StackInfo>(); }
 

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -485,7 +485,6 @@ public:
 	virtual void debug_get_stack_level_members(int p_level, List<String> *p_members, List<Variant> *p_values, int p_max_subitems = -1, int p_max_depth = -1);
 	virtual ScriptInstance *debug_get_stack_level_instance(int p_level);
 	virtual void debug_get_globals(List<String> *p_globals, List<Variant> *p_values, int p_max_subitems = -1, int p_max_depth = -1);
-	virtual String debug_parse_stack_level_expression(int p_level, const String &p_expression, int p_max_subitems = -1, int p_max_depth = -1);
 
 	virtual void reload_all_scripts();
 	virtual void reload_tool_script(const Ref<Script> &p_script, bool p_soft_reload);

--- a/modules/gdscript/gdscript.h
+++ b/modules/gdscript/gdscript.h
@@ -485,6 +485,7 @@ public:
 	virtual void debug_get_stack_level_members(int p_level, List<String> *p_members, List<Variant> *p_values, int p_max_subitems = -1, int p_max_depth = -1);
 	virtual ScriptInstance *debug_get_stack_level_instance(int p_level);
 	virtual void debug_get_globals(List<String> *p_globals, List<Variant> *p_values, int p_max_subitems = -1, int p_max_depth = -1);
+	virtual void debug_get_named_globals(List<String> *p_globals, List<Variant> *p_values);
 
 	virtual void reload_all_scripts();
 	virtual void reload_tool_script(const Ref<Script> &p_script, bool p_soft_reload);

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -390,6 +390,14 @@ void GDScriptLanguage::debug_get_globals(List<String> *p_globals, List<Variant> 
 	}
 }
 
+void GDScriptLanguage::debug_get_named_globals(List<String> *p_globals, List<Variant> *p_values) {
+
+	for (const Map<StringName, Variant>::Element *E = get_named_globals_map().front(); E; E = E->next()) {
+		p_globals->push_back(E->key());
+		p_values->push_back(E->value());
+	}
+}
+
 void GDScriptLanguage::get_recognized_extensions(List<String> *p_extensions) const {
 
 	p_extensions->push_back("gd");

--- a/modules/gdscript/gdscript_editor.cpp
+++ b/modules/gdscript/gdscript_editor.cpp
@@ -390,11 +390,6 @@ void GDScriptLanguage::debug_get_globals(List<String> *p_globals, List<Variant> 
 	}
 }
 
-String GDScriptLanguage::debug_parse_stack_level_expression(int p_level, const String &p_expression, int p_max_subitems, int p_max_depth) {
-
-	return "";
-}
-
 void GDScriptLanguage::get_recognized_extensions(List<String> *p_extensions) const {
 
 	p_extensions->push_back("gd");

--- a/modules/gdscript/gdscript_function.cpp
+++ b/modules/gdscript/gdscript_function.cpp
@@ -1590,6 +1590,10 @@ Variant GDScriptFunction::call(GDScriptInstance *p_instance, const Variant **p_a
 					if (ScriptDebugger::get_singleton()->is_breakpoint(line, source))
 						do_break = true;
 
+					if (ScriptDebugger::get_singleton()->evaluate_watches()) {
+						do_break = true;
+					}
+
 					if (do_break) {
 						GDScriptLanguage::get_singleton()->debug_break("Breakpoint", true);
 					}

--- a/modules/visual_script/visual_script.cpp
+++ b/modules/visual_script/visual_script.cpp
@@ -2676,6 +2676,8 @@ void VisualScriptLanguage::debug_get_globals(List<String> *p_locals, List<Varian
 	//no globals are really reachable in gdscript
 }
 
+void VisualScriptLanguage::debug_get_named_globals(List<String> *p_globals, List<Variant> *p_values) {}
+
 void VisualScriptLanguage::reload_all_scripts() {
 }
 void VisualScriptLanguage::reload_tool_script(const Ref<Script> &p_script, bool p_soft_reload) {

--- a/modules/visual_script/visual_script.cpp
+++ b/modules/visual_script/visual_script.cpp
@@ -2675,10 +2675,6 @@ void VisualScriptLanguage::debug_get_globals(List<String> *p_locals, List<Varian
 
 	//no globals are really reachable in gdscript
 }
-String VisualScriptLanguage::debug_parse_stack_level_expression(int p_level, const String &p_expression, int p_max_subitems, int p_max_depth) {
-
-	return "";
-}
 
 void VisualScriptLanguage::reload_all_scripts() {
 }

--- a/modules/visual_script/visual_script.h
+++ b/modules/visual_script/visual_script.h
@@ -590,7 +590,6 @@ public:
 	virtual void debug_get_stack_level_locals(int p_level, List<String> *p_locals, List<Variant> *p_values, int p_max_subitems = -1, int p_max_depth = -1);
 	virtual void debug_get_stack_level_members(int p_level, List<String> *p_members, List<Variant> *p_values, int p_max_subitems = -1, int p_max_depth = -1);
 	virtual void debug_get_globals(List<String> *p_locals, List<Variant> *p_values, int p_max_subitems = -1, int p_max_depth = -1);
-	virtual String debug_parse_stack_level_expression(int p_level, const String &p_expression, int p_max_subitems = -1, int p_max_depth = -1);
 
 	virtual void reload_all_scripts();
 	virtual void reload_tool_script(const Ref<Script> &p_script, bool p_soft_reload);

--- a/modules/visual_script/visual_script.h
+++ b/modules/visual_script/visual_script.h
@@ -590,6 +590,7 @@ public:
 	virtual void debug_get_stack_level_locals(int p_level, List<String> *p_locals, List<Variant> *p_values, int p_max_subitems = -1, int p_max_depth = -1);
 	virtual void debug_get_stack_level_members(int p_level, List<String> *p_members, List<Variant> *p_values, int p_max_subitems = -1, int p_max_depth = -1);
 	virtual void debug_get_globals(List<String> *p_locals, List<Variant> *p_values, int p_max_subitems = -1, int p_max_depth = -1);
+	virtual void debug_get_named_globals(List<String> *p_locals, List<Variant> *p_values);
 
 	virtual void reload_all_scripts();
 	virtual void reload_tool_script(const Ref<Script> &p_script, bool p_soft_reload);

--- a/scene/debugger/script_debugger_remote.cpp
+++ b/scene/debugger/script_debugger_remote.cpp
@@ -33,6 +33,7 @@
 #include "core/engine.h"
 #include "core/io/ip.h"
 #include "core/io/marshalls.h"
+#include "core/math/expression.h"
 #include "core/os/input.h"
 #include "core/os/os.h"
 #include "core/project_settings.h"
@@ -60,6 +61,41 @@ void ScriptDebuggerRemote::_send_video_memory() {
 		packet_peer_stream->put_var(E->get().format);
 		packet_peer_stream->put_var(E->get().vram);
 	}
+}
+
+void ScriptDebuggerRemote::_execute_expression(int stack_frame, const String &p_expression) {
+	String result;
+	bool success = evaluate_expression(stack_frame, p_expression, result);
+
+	packet_peer_stream->put_var("message:expression_result");
+	packet_peer_stream->put_var(2);
+	packet_peer_stream->put_var(success);
+	packet_peer_stream->put_var(result);
+}
+
+void ScriptDebuggerRemote::_update_watch(int p_index) {
+	const bool success = !watch_has_error(p_index);
+	String result;
+	if (success) {
+		result = get_watch_result(p_index).get_construct_string();
+	} else {
+		result = get_watch_error_text(p_index);
+	}
+
+	packet_peer_stream->put_var("message:watch_update");
+	packet_peer_stream->put_var(3);
+	packet_peer_stream->put_var(success);
+	packet_peer_stream->put_var(p_index);
+	packet_peer_stream->put_var(result);
+
+	set_watch_dirty(p_index, false);
+}
+
+void ScriptDebuggerRemote::_send_remove_watch(int p_index) {
+
+	packet_peer_stream->put_var("message:watch_remove");
+	packet_peer_stream->put_var(1);
+	packet_peer_stream->put_var(p_index);
 }
 
 Error ScriptDebuggerRemote::connect_to_host(const String &p_host, uint16_t p_port) {
@@ -292,6 +328,57 @@ void ScriptDebuggerRemote::debug(ScriptLanguage *p_script, bool p_can_continue, 
 			} else if (command == "request_video_mem") {
 
 				_send_video_memory();
+			} else if (command == "execute_expression") {
+
+				_execute_expression(cmd[1], cmd[2]);
+			} else if (command == "add_watch") {
+
+				const int stack_level = cmd[1];
+				const String &expression = cmd[2];
+
+				add_watch(stack_level, expression);
+
+				int index = get_watch_count() - 1;
+				(void)evaluate_watches(stack_level, index);
+			} else if (command == "remove_watch") {
+
+				int index = cmd[1];
+				remove_watch(index);
+			} else if (command == "watch_expression") {
+
+				const int stack_level = cmd[1];
+				int index = cmd[2];
+				const String &expression = cmd[3];
+
+				set_watch_expression(stack_level, index, expression);
+				(void)evaluate_watches(stack_level, index);
+			} else if (command == "watch_tracking") {
+
+				int index = cmd[1];
+				bool is_tracked = cmd[2];
+				set_watch_tracking(index, is_tracked);
+			} else if (command == "watch_lock") {
+
+				const int stack_level = cmd[1];
+				int index = cmd[2];
+				bool is_locked = cmd[3];
+				set_watch_lock(stack_level, index, is_locked);
+			} else if (command == "eval_watches") {
+
+				int stack_level = cmd[1];
+
+				(void)evaluate_watches(stack_level);
+				for (int i = 0; i < get_watch_count(); ++i) {
+					if (watch_is_dirty(i)) {
+						_update_watch(i);
+					}
+				}
+			} else if (command == "refresh_watches") {
+				for (int i = 0; i < get_watch_count(); ++i) {
+					if (watch_is_dirty(i)) {
+						_update_watch(i);
+					}
+				}
 			} else if (command == "inspect_object") {
 
 				ObjectID id = cmd[1];
@@ -473,6 +560,23 @@ void ScriptDebuggerRemote::line_poll() {
 	if (poll_every % 2048 == 0)
 		_poll_events();
 	poll_every++;
+
+	ScriptDebugger *const debugger = ScriptDebugger::get_singleton();
+	ScriptLanguage *const lang = get_break_language();
+	// Currently, stepping through code in debugger brings focus back to the most recent stack level
+	const int stack_level = 0;
+	const int inverse_stack_level = lang->debug_get_stack_level_count() - stack_level - 1;
+
+	// Checking for stale watches
+	for (int i = 0; i < get_watch_count(); i++) {
+		if (
+				watches[i].inverse_stack_level > inverse_stack_level ||
+				(watches[i].inverse_stack_level == 0 && debugger->get_depth() == -1) ||
+				(watches[i].base_id != 0 && ObjectDB::get_instance(watches[i].base_id) == NULL)) {
+			_send_remove_watch(i);
+			remove_watch(i);
+		}
+	}
 }
 
 void ScriptDebuggerRemote::_err_handler(void *ud, const char *p_func, const char *p_file, int p_line, const char *p_err, const char *p_descr, ErrorHandlerType p_type) {
@@ -773,6 +877,46 @@ void ScriptDebuggerRemote::_poll_events() {
 		} else if (command == "request_video_mem") {
 
 			_send_video_memory();
+		} else if (command == "watch_tracking") {
+
+			int index = cmd[1];
+			bool is_tracked = cmd[2];
+
+			set_watch_tracking(index, is_tracked);
+		} else if (command == "add_watch") {
+
+			const int stack_level = cmd[1];
+			const String &expression = cmd[2];
+
+			add_watch(stack_level, expression);
+
+			int index = get_watch_count() - 1;
+			(void)evaluate_watches(stack_level, index);
+		} else if (command == "remove_watch") {
+
+			int index = cmd[1];
+			remove_watch(index);
+		} else if (command == "watch_expression") {
+
+			const int stack_level = cmd[1];
+			int index = cmd[2];
+			const String &expression = cmd[3];
+
+			set_watch_expression(stack_level, index, expression);
+			(void)evaluate_watches(stack_level, index);
+		} else if (command == "watch_lock") {
+
+			const int stack_level = cmd[1];
+			int index = cmd[2];
+			bool is_locked = cmd[3];
+			set_watch_lock(stack_level, index, is_locked);
+		} else if (command == "refresh_watches") {
+
+			for (int i = 0; i < get_watch_count(); ++i) {
+				if (watch_is_dirty(i)) {
+					_update_watch(i);
+				}
+			}
 		} else if (command == "inspect_object") {
 
 			ObjectID id = cmd[1];

--- a/scene/debugger/script_debugger_remote.cpp
+++ b/scene/debugger/script_debugger_remote.cpp
@@ -877,6 +877,9 @@ void ScriptDebuggerRemote::_poll_events() {
 		} else if (command == "request_video_mem") {
 
 			_send_video_memory();
+		} else if (command == "execute_expression") {
+
+			_execute_expression(cmd[1], cmd[2]);
 		} else if (command == "watch_tracking") {
 
 			int index = cmd[1];

--- a/scene/debugger/script_debugger_remote.h
+++ b/scene/debugger/script_debugger_remote.h
@@ -128,6 +128,11 @@ class ScriptDebuggerRemote : public ScriptDebugger {
 	void _send_video_memory();
 
 	Ref<MultiplayerAPI> multiplayer;
+	
+	void _execute_expression(int stack_frame, const String &expression);
+
+	void _update_watch(int p_index);
+	void _send_remove_watch(int p_index);
 
 	ErrorHandlerList eh;
 	static void _err_handler(void *, const char *, const char *, int p_line, const char *, const char *, ErrorHandlerType p_type);


### PR DESCRIPTION
Evaluator allows  expressions to be evaluated in the current stack frame.
Watches keep track of a list of expressions.

The original PR:  https://github.com/godotengine/godot/pull/26219
This is still a WIP. Testing and feedback is much appreciated.
CC @jahd2602 